### PR TITLE
bugfix: disable body on GET/DELETE requests

### DIFF
--- a/src/header.js
+++ b/src/header.js
@@ -1,16 +1,17 @@
 export const destinationUrlHeader = 'x-relay-url';
-const contentTypeHeader = 'content-type';
+const alwaysIncludeBodyHeader = 'x-include-body';
 
 export function expressToAxiosRequest(req) {
     const headers = Object.assign({}, req.headers);
-    const contentType = headers[contentTypeHeader];
-
-    if (contentType === undefined) {
-        delete req.body;
-    }
+    const alwaysIncludeBody = headers[alwaysIncludeBodyHeader] !== undefined;
 
     const url = headers[destinationUrlHeader];
     const method = req.method;
+
+    if (!alwaysIncludeBody && !method.startsWith('P')) {
+        delete req.body;
+    }
+
     let data = req.body;
 
     delete headers[destinationUrlHeader];


### PR DESCRIPTION
You can bypass this rule by including the `X-Include-Body` header with any arbitrary value